### PR TITLE
Changing how directory_hash_id deals with UUIDs

### DIFF
--- a/galaxy/util/directory_hash.py
+++ b/galaxy/util/directory_hash.py
@@ -11,7 +11,7 @@ def directory_hash_id( id ):
     >>> directory_hash_id("777777777")
     ['000', '777', '777']
     >>> directory_hash_id("135ee48a-4f51-470c-ae2f-ce8bd78799e6")
-    ['13']
+    ['1','3','5']
     """
     s = str( id )
     l = len( s )

--- a/galaxy/util/directory_hash.py
+++ b/galaxy/util/directory_hash.py
@@ -9,15 +9,21 @@ def directory_hash_id( id ):
     ['090']
     >>> directory_hash_id("777777777")
     ['000', '777', '777']
+    >>> directory_hash_id("135ee48a-4f51-470c-ae2f-ce8bd78799e6")
+    ['13']
     """
     s = str( id )
     l = len( s )
     # Shortcut -- ids 0-999 go under ../000/
     if l < 4:
         return [ "000" ]
-    # Pad with zeros until a multiple of three
-    padded = ( ( 3 - len( s ) % 3 ) * "0" ) + s
-    # Drop the last three digits -- 1000 files per directory
-    padded = padded[:-3]
-    # Break into chunks of three
-    return [ padded[ i * 3 : (i + 1 ) * 3 ] for i in range( len( padded ) // 3 ) ]
+    if l < 10:
+        # Pad with zeros until a multiple of three
+        padded = ( ( 3 - len( s ) % 3 ) * "0" ) + s
+        # Drop the last three digits -- 1000 files per directory
+        padded = padded[:-3]
+        # Break into chunks of three
+        return [ padded[ i * 3 : (i + 1 ) * 3 ] for i in range( len( padded ) // 3 ) ]
+    else:
+        #assume it is a UUID
+        return [ s[0:2] ]

--- a/galaxy/util/directory_hash.py
+++ b/galaxy/util/directory_hash.py
@@ -1,4 +1,5 @@
 
+from galaxy.util import is_uuid
 
 def directory_hash_id( id ):
     """
@@ -17,7 +18,7 @@ def directory_hash_id( id ):
     # Shortcut -- ids 0-999 go under ../000/
     if l < 4:
         return [ "000" ]
-    if l < 10:
+    if not is_uuid(s):
         # Pad with zeros until a multiple of three
         padded = ( ( 3 - len( s ) % 3 ) * "0" ) + s
         # Drop the last three digits -- 1000 files per directory
@@ -26,4 +27,4 @@ def directory_hash_id( id ):
         return [ padded[ i * 3 : (i + 1 ) * 3 ] for i in range( len( padded ) // 3 ) ]
     else:
         #assume it is a UUID
-        return [ s[0:2] ]
+        return list(iter(s[0:3]))


### PR DESCRIPTION
If a UUID is passed directory_hash_id, currently it would produce something like
/000/c39/ded/10-/607/3-1/1e4/-98/03-/080/020/0c9

This modifies the behavior so that it creates a directory based on the first two characters of the ID. For a UUID, this would produce 256 possible sub directories.