### PR TITLE
Fix for downloading a url using wget: "-k or -r can be used together with -O only if outputting to a regular file."

### DIFF
--- a/galaxy/tools/deps/commands.py
+++ b/galaxy/tools/deps/commands.py
@@ -70,7 +70,7 @@ def download_command(url, quote_url=False):
     if quote_url:
         url = "'%s'" % url
     if which("wget"):
-        download_cmd = ["wget", "-q", "--recursive", "-O" "-", url]
+        download_cmd = ["wget", "-q", "-O" "-", url]
     else:
         download_cmd = ["curl", "-L", url]
     return download_cmd


### PR DESCRIPTION
Remove --recursive from wget command

Current implementation 
fails on:
`GNU Wget 1.17.1 built on darwin13.4.0.`
`GNU Wget 1.17.1 built on linux-gnu.`

works on 
`GNU Wget 1.13.4 built on linux-gnu.`