### PR TITLE
New features for mulled

### DIFF
--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -28,12 +28,18 @@ for i = 1, #targets do
     target_args = target_args .. " " .. targets[i]
 end
 
+local bind_args = {"build/dist:/usr/local/"}
+local binds_table = VAR.BINDS:split(",")
+for i = 1, #binds_table do
+    table.insert(bind_args, binds_table[i])
+end
+
 inv.task('build')
     .using('continuumio/miniconda:latest')
         .withHostConfig({binds = {"build:/data"}})
         .run('rm', '-rf', '/data/dist')
     .using('continuumio/miniconda:latest')
-        .withHostConfig({binds = {"build/dist:/usr/local/"}})
+        .withHostConfig({binds = bind_args})
         .run('/bin/sh', '-c', 'conda install '
             .. channel_args .. ' '
             .. target_args


### PR DESCRIPTION
* fix bug in executing `mulled_build`
* test parameter to override the tests
* allow local file to be build

We can do something like this now:

```sh
conda build recipes/samtools
conda index /home/bag/miniconda2/conda-bld/linux-64/
mulled-build build-and-test 'samtools=3.0' --extra-channel file://home/bag/miniconda2/conda-bld/ --test 'samtools --help' 

```