### PR TITLE
Revert commands.shell changes from galaxyproject/galaxy#3129.

### DIFF
--- a/galaxy/tools/deps/commands.py
+++ b/galaxy/tools/deps/commands.py
@@ -34,19 +34,13 @@ def shell(cmds, env=None, **kwds):
     """Run shell commands with `shell_process` and wait."""
     sys = kwds.get("sys", _sys)
     assert sys is not None
+    p = shell_process(cmds, env, **kwds)
     if redirecting_io(sys=sys):
-        p = shell_process(cmds, env, **kwds)
         redirect_aware_commmunicate(p, sys=sys)
         exit = p.returncode
         return exit
     else:
-        kwds['stdout'] = subprocess.PIPE
-        kwds['stderr'] = subprocess.PIPE
-        p = shell_process(cmds, env, **kwds)
-        stdout, stderr = p.communicate()
-        if p.returncode != 0:
-            raise CommandLineException(cmds, stdout, stderr, p.returncode)
-        return p.returncode
+        return p.wait()
 
 
 def shell_process(cmds, env=None, **kwds):
@@ -98,7 +92,7 @@ def _wait(cmds, **popen_kwds):
     p = subprocess.Popen(cmds, **popen_kwds)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
-        raise CommandLineException(argv_to_str(cmds), stdout, stderr)
+        raise CommandLineException(argv_to_str(cmds), stdout, stderr, p.returncode)
     return stdout
 
 


### PR DESCRIPTION
It seems like people prefer to see the interactive shell https://github.com/galaxyproject/galaxy/issues/3259. See follow up here https://github.com/galaxyproject/galaxy/issues/3309.

This also fixes an issue caused by the change of the constructor interface for CommandLineException in galaxyproject/galaxy#3129.