### PR TITLE
Add possibility to mount in test-files during conda testing

### DIFF
--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -34,6 +34,12 @@ for i = 1, #binds_table do
     table.insert(bind_args, binds_table[i])
 end
 
+local test_bind_args = {}
+local test_binds_table = VAR.TEST_BINDS:split(",")
+for i = 1, #test_binds_table do
+    table.insert(test_bind_args, test_binds_table[i])
+end
+
 inv.task('build')
     .using('continuumio/miniconda:latest')
         .withHostConfig({binds = {"build:/data"}})
@@ -49,10 +55,18 @@ inv.task('build')
         .inImage('bgruening/busybox-bash:0.1')
         .as(repo)
 
-inv.task('test')
-    .using(repo)
-    .withConfig({entrypoint = {'/bin/sh', '-c'}})
-    .run(VAR.TEST)
+if VAR.TEST_BINDS == '' then
+    inv.task('test')
+        .using(repo)
+        .withConfig({entrypoint = {'/bin/sh', '-c'}})
+        .run(VAR.TEST)
+else
+    inv.task('test')
+        .using(repo)
+        .withHostConfig({binds = test_bind_args})
+        .withConfig({entrypoint = {'/bin/sh', '-c'}})
+        .run(VAR.TEST)
+end
 
 inv.task('push')
     .push(repo)

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -149,11 +149,14 @@ def mull_targets(
         test_bind = []
         for test_file in test_files:
             if ':' not in test_file:
-                test_bind.append("%s:%s/%s" % (test_file, DEFAULT_WORKING_DIR, test_file))
+                if os.path.exists(test_file):
+                    test_bind.append("%s:%s/%s" % (test_file, DEFAULT_WORKING_DIR, test_file))
             else:
-                test_bind.append(test_file)
-        involucro_args.insert(6, '-set')
-        involucro_args.insert(7, "TEST_BINDS='%s'" % ",".join(test_bind))
+                if os.path.exists(test_file.split(':')[0]):
+                    test_bind.append(test_file)
+        if test_bind:
+            involucro_args.insert(6, '-set')
+            involucro_args.insert(7, "TEST_BINDS='%s'" % ",".join(test_bind))
     print(" ".join(involucro_context.build_command(involucro_args)))
     if not dry_run:
         ensure_installed(involucro_context, True)


### PR DESCRIPTION
With this change bioconda-utils could be adapted to specifically mount in files that are specified in a meta.yaml file. Not sure this makes a lot of sense atm, since the recipe folder is mounted anyway in /source during testing.

To test, you can launch commands like this:
```
mulled-build build-and-test 'samtools=1.3.1' --involucro /home/mvdbeek/conda3/bin/involucro --channel bioconda --extra-channel file://home/mvdbeek/conda3/conda-bld/ --test 'cat /test && cat /test2' --test-files test:/test,test:/test2
```

Ping @bgruening 