### PR TITLE
Allow conda to be configured to use locally built packages.

### DIFF
--- a/galaxy/tools/deps/conda_util.py
+++ b/galaxy/tools/deps/conda_util.py
@@ -30,6 +30,7 @@ VERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@(.*)")
 UNVERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@_uv_")
 USE_PATH_EXEC_DEFAULT = False
 CONDA_VERSION = "4.2.13"
+USE_LOCAL_DEFAULT = False
 
 
 def conda_link():
@@ -54,7 +55,8 @@ class CondaContext(installable.InstallableContext):
 
     def __init__(self, conda_prefix=None, conda_exec=None,
                  shell_exec=None, debug=False, ensure_channels='',
-                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT, copy_dependencies=False):
+                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT,
+                 use_local=USE_LOCAL_DEFAULT, copy_dependencies=False):
         self.condarc_override = condarc_override
         if not conda_exec and use_path_exec:
             conda_exec = commands.which("conda")
@@ -84,6 +86,7 @@ class CondaContext(installable.InstallableContext):
         self.ensured_channels = False
         self._conda_version = None
         self._miniconda_version = None
+        self._use_local = use_local
 
     @property
     def conda_version(self):
@@ -230,6 +233,8 @@ class CondaContext(installable.InstallableContext):
         create_base_args = [
             "-y"
         ]
+        if self._use_local:
+            create_base_args.extend(["--use-local"])
         create_base_args.extend(args)
         return self.exec_command("create", create_base_args)
 
@@ -246,6 +251,8 @@ class CondaContext(installable.InstallableContext):
         install_base_args = [
             "-y"
         ]
+        if self._use_local:
+            install_base_args.extend(["--use-local"])
         install_base_args.extend(args)
         return self.exec_command("install", install_base_args)
 

--- a/galaxy/tools/deps/resolvers/conda.py
+++ b/galaxy/tools/deps/resolvers/conda.py
@@ -55,6 +55,7 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         'auto_install': False,
         'auto_init': True,
         'copy_dependencies': False,
+        'use_local': False,
     }
     _specification_pattern = re.compile(r"https\:\/\/anaconda.org\/\w+\/\w+")
 
@@ -83,6 +84,7 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
             )
 
         copy_dependencies = _string_as_bool(get_option("copy_dependencies"))
+        use_local = _string_as_bool(get_option("use_local"))
         conda_exec = get_option("exec")
         debug = _string_as_bool(get_option("debug"))
         ensure_channels = get_option("ensure_channels")
@@ -101,7 +103,8 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
             ensure_channels=ensure_channels,
             condarc_override=condarc_override,
             use_path_exec=use_path_exec,
-            copy_dependencies=copy_dependencies
+            copy_dependencies=copy_dependencies,
+            use_local=use_local,
         )
         self.ensure_channels = ensure_channels
 


### PR DESCRIPTION
This is required to run tests and such with new and updated local packages before they have been published.