### PR TITLE
A couple more important Conda updates for Planemo

### DIFF
--- a/galaxy/tools/deps/conda_util.py
+++ b/galaxy/tools/deps/conda_util.py
@@ -47,7 +47,16 @@ def find_conda_prefix(conda_prefix=None):
     for Miniconda installs.
     """
     if conda_prefix is None:
-        return os.path.join(os.path.expanduser("~"), "miniconda2")
+        home = os.path.expanduser("~")
+        miniconda_2_dest = os.path.join(home, "miniconda2")
+        miniconda_3_dest = os.path.join(home, "miniconda3")
+        # Prefer miniconda3 install if both available
+        if os.path.exists(miniconda_3_dest):
+            return miniconda_3_dest
+        elif os.path.exists(miniconda_2_dest):
+            return miniconda_2_dest
+        else:
+            return miniconda_3_dest
     return conda_prefix
 
 

--- a/galaxy/tools/deps/resolvers/conda.py
+++ b/galaxy/tools/deps/resolvers/conda.py
@@ -113,6 +113,8 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         self.auto_init = _string_as_bool(get_option("auto_init"))
         self.conda_context = conda_context
         self.disabled = not galaxy.tools.deps.installable.ensure_installed(conda_context, install_conda, self.auto_init)
+        if self.auto_init and not self.disabled:
+            self.conda_context.ensure_conda_build_installed_if_needed()
         self.auto_install = auto_install
         self.copy_dependencies = copy_dependencies
 


### PR DESCRIPTION
- Ensure conda-build is installed if conda_use_local is set (hadn't realized this was a requirement). 	bdacc4d
- Update default prefix to use miniconda3 in path unless an existing miniconda2 path is already written.