### PR TITLE
Add more flexibility to mulled operations.

### DIFF
--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -40,19 +40,47 @@ for i = 1, #test_binds_table do
     table.insert(test_bind_args, test_binds_table[i])
 end
 
+local conda_image = VAR.CONDA_IMAGE
+if conda_image == '' then
+    conda_image = 'continuumio/miniconda:latest'
+end
+
+local destination_base_image = VAR.DEST_BASE_IMAGE
+if destination_base_image == '' then
+    destination_base_image = 'bgruening/busybox-bash:0.1'
+end
+
+local verbose = VAR.VERBOSE
+if verbose == '' then
+    VERBOSE = '--queit'
+end
+
+local preinstall = VAR.PREINSTALL
+if preinstall ~= '' then
+    preinstall = preinstall .. ' && '
+end
+
+local postinstall = VAR.POSTINSTALL
+if postinstall ~= '' then
+    postinstall = '&&' .. postinstall
+end
+
 inv.task('build')
-    .using('continuumio/miniconda:latest')
+    .using(conda_image)
         .withHostConfig({binds = {"build:/data"}})
         .run('rm', '-rf', '/data/dist')
-    .using('continuumio/miniconda:latest')
+    .using(conda_image)
         .withHostConfig({binds = bind_args})
-        .run('/bin/sh', '-c', 'conda install '
+        .run('/bin/sh', '-c', preinstall
+            .. 'conda install '
             .. channel_args .. ' '
             .. target_args
-            .. ' -p /usr/local --copy --yes --quiet')
+            .. ' -p /usr/local --copy --yes'
+            .. verbose
+            .. postinstall)
     .wrap('build/dist')
         .at('/usr/local')
-        .inImage('bgruening/busybox-bash:0.1')
+        .inImage(destination_base_image)
         .as(repo)
 
 if VAR.TEST_BINDS == '' then

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -116,7 +116,7 @@ def mull_targets(
     command="build", channels=DEFAULT_CHANNELS, namespace="mulled",
     test='true', test_files=None, image_build=None, name_override=None,
     repository_template=DEFAULT_REPOSITORY_TEMPLATE, dry_run=False,
-    binds=DEFAULT_BINDS
+    conda_version=False, verbose=False, binds=DEFAULT_BINDS
 ):
     targets = list(targets)
     if involucro_context is None:
@@ -143,8 +143,13 @@ def mull_targets(
         '-set', "TARGETS='%s'" % target_str,
         '-set', "REPO='%s'" % repo,
         '-set', "BINDS='%s'" % bind_str,
-        command,
     ]
+    if verbose:
+        involucro_args.extend(["-set", "VERBOSE='1'"])
+    if conda_version is not None:
+        verbose = "--verbose" if verbose else "--quiet"
+        involucro_args.extend(["-set", "PREINSTALL='conda install %s --yes conda=%s'" % (verbose, conda_version)])
+    involucro_args.append(command)
     if test_files:
         test_bind = []
         for test_file in test_files:
@@ -165,7 +170,8 @@ def mull_targets(
 
 
 def context_from_args(args):
-    return InvolucroContext(involucro_bin=args.involucro_path)
+    verbose = "2" if not args.verbose else "3"
+    return InvolucroContext(involucro_bin=args.involucro_path, verbose=verbose)
 
 
 class InvolucroContext(installable.InstallableContext):
@@ -220,6 +226,8 @@ def add_build_arguments(parser):
                         help="Rebuild package even if already published.")
     parser.add_argument('--dry-run', dest='dry_run', action="store_true",
                         help='Just print commands instead of executing them.')
+    parser.add_argument('--verbose', dest='verbose', action="store_true",
+                        help='Cause process to be verbose.')
     parser.add_argument('-n', '--namespace', dest='namespace', default="mulled",
                         help='quay.io namespace.')
     parser.add_argument('-r', '--repository_template', dest='repository_template', default=DEFAULT_REPOSITORY_TEMPLATE,
@@ -228,6 +236,8 @@ def add_build_arguments(parser):
                         help='Target conda channel')
     parser.add_argument('--extra-channels', dest='extra_channels', default=",".join(DEFAULT_EXTRA_CHANNELS),
                         help='Dependent conda channels.')
+    parser.add_argument('--conda-version', dest="conda_version", default=None,
+                        help="Change to specified version of Conda before installing packages.")
 
 
 def add_single_image_arguments(parser):
@@ -277,6 +287,8 @@ def args_to_mull_targets_kwds(args):
         kwds["command"] = args.command
     if hasattr(args, "repository_template"):
         kwds["repository_template"] = args.repository_template
+    if hasattr(args, "conda_version"):
+        kwds["conda_version"] = args.conda_version
 
     kwds["involucro_context"] = context_from_args(args)
 


### PR DESCRIPTION
Clean up verbose handling and such but the major fix is the addition of allowing a specified version of Conda to be installed before building images - this is required to work around certain packages such ncurses not working under osxfs and conda=4.2. This is fixed with Conda 4.3.

Likely this bug is related to https://github.com/conda/conda/issues/3494.