### PR TITLE
Add location fetching for Galaxy tools.

### DIFF
--- a/galaxy/tools/fetcher.py
+++ b/galaxy/tools/fetcher.py
@@ -1,0 +1,28 @@
+from galaxy.util import plugin_config
+
+
+class ToolLocationFetcher(object):
+
+    def __init__(self):
+        self.resolver_classes = self.__resolvers_dict()
+
+    def __resolvers_dict( self ):
+        import galaxy.tools.locations
+        return plugin_config.plugins_dict(galaxy.tools.locations, 'scheme')
+
+    def to_tool_path(self, path_or_uri_like, **kwds):
+        if "://" not in path_or_uri_like:
+            path = path_or_uri_like
+        else:
+            uri_like = path_or_uri_like
+            if ":" not in path_or_uri_like:
+                raise Exception("Invalid URI passed to get_tool_source")
+            scheme, rest = uri_like.split(":", 2)
+            if scheme not in self.resolver_classes:
+                raise Exception("Unknown tool scheme [%s] for URI [%s]" % (scheme, uri_like))
+            path = self.resolver_classes[scheme]().get_tool_source_path(uri_like)
+
+        return path
+
+
+DEFAULT_TOOL_LOCATION_FETCHER = ToolLocationFetcher()

--- a/galaxy/tools/locations/__init__.py
+++ b/galaxy/tools/locations/__init__.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+
+from abc import (
+    ABCMeta,
+    abstractmethod,
+    abstractproperty,
+)
+
+import six
+
+
+@six.add_metaclass(ABCMeta)
+class ToolLocationResolver(object):
+    """Parse a URI-like string and return a ToolSource object."""
+
+    @abstractproperty
+    def scheme(self):
+        """Short label for the type of location resolver and URI scheme."""
+
+    @abstractmethod
+    def get_tool_source_path(self, uri_like):
+        """Return a local path for the uri_like string."""
+
+    def _temp_path(self, uri_like):
+        """Create an abstraction for this so we can configure and cache later."""
+        handle, filename = tempfile.mkstemp(suffix=uri_like.split("/")[-1])
+        os.close(handle)
+        return filename

--- a/galaxy/tools/locations/dockstore.py
+++ b/galaxy/tools/locations/dockstore.py
@@ -1,0 +1,69 @@
+try:
+    import requests
+except ImportError:
+    requests = None
+import yaml
+
+from six.moves.urllib.parse import quote
+
+from ..locations import (
+    ToolLocationResolver,
+)
+
+
+class DockStoreResolver(ToolLocationResolver):
+
+    scheme = "dockstore"
+
+    def get_tool_source_path(self, uri_like):
+        assert uri_like.startswith("dockstore://")
+        tool_id = uri_like[len("dockstore://"):]
+        if ":" in tool_id:
+            tool_id, version = tool_id.split(":", 1)
+        else:
+            tool_id, version = tool_id, "latest"
+        tmp_path = self._temp_path(uri_like + ".cwl")
+        cwl_str = _Ga4ghToolClient().get_tool_cwl(tool_id, version=version, as_string=True)
+        with open(tmp_path, "wb") as f:
+            f.write(cwl_str)
+        return tmp_path
+
+
+class _Ga4ghToolClient(object):
+
+    def __init__(self, base_url="https://www.dockstore.org:8443/api"):
+        self.base_url = base_url
+
+    def get_tools(self):
+        return self._requests.get("%s/ga4gh/v1/tools" % self.base_url)
+
+    def get_tool(self, tool_id):
+        url = "%s/ga4gh/v1/tools/%s" % (self.base_url, quote(tool_id, safe=''))
+        return self._requests.get(url)
+
+    def get_tool_version(self, tool_id, version="latest"):
+        url = "%s/ga4gh/v1/tools/%s/versions/%s" % (self.base_url, quote(tool_id, safe=''), version)
+        return self._requests.get(url)
+
+    def get_tool_descriptor(self, tool_id, version="latest", tool_type="CWL"):
+        url = "%s/ga4gh/v1/tools/%s/versions/%s/%s/descriptor" % (self.base_url, quote(tool_id, safe=''), version, tool_type)
+        return self._requests.get(url)
+
+    def get_tool_cwl(self, tool_id, version="latest", as_string=False):
+        tool_type = "CWL"
+        url = "%s/ga4gh/v1/tools/%s/versions/%s/%s/descriptor" % (self.base_url, quote(tool_id, safe=''), version, tool_type)
+        descriptor_response = self._requests.get(url)
+        descriptor_str = descriptor_response.json()["descriptor"]
+        if as_string:
+            return descriptor_str
+        else:
+            return yaml.load(descriptor_str)
+
+    @property
+    def _requests(self):
+        if requests is None:
+            raise Exception("requests Python library needs to be installed use GA4GH APIs")
+        return requests
+
+
+__all__ = ("DockStoreResolver",)

--- a/galaxy/tools/locations/file.py
+++ b/galaxy/tools/locations/file.py
@@ -1,0 +1,12 @@
+from ..locations import (
+    ToolLocationResolver,
+)
+
+
+class HttpToolResolver(ToolLocationResolver):
+
+    scheme = "file"
+
+    def get_tool_source_path(self, uri_like):
+        assert uri_like.startswith("file://")
+        return uri_like[len("file://"):]

--- a/galaxy/tools/locations/http.py
+++ b/galaxy/tools/locations/http.py
@@ -1,0 +1,26 @@
+from galaxy.util import download_to_file
+
+from ..locations import (
+    ToolLocationResolver,
+)
+
+
+class HttpToolResolver(ToolLocationResolver):
+
+    scheme = "http"
+
+    def __init__(self, **kwds):
+        pass
+
+    def get_tool_source_path(self, uri_like):
+        tmp_path = self._temp_path(uri_like)
+        download_to_file(uri_like, tmp_path)
+        return tmp_path
+
+
+class HttpsToolResolver(HttpToolResolver):
+
+    scheme = "https"
+
+
+__all__ = ("HttpToolResolver", "HttpsToolResolver")

--- a/galaxy/tools/parser/factory.py
+++ b/galaxy/tools/parser/factory.py
@@ -13,10 +13,12 @@ from .interface import InputSource
 from .xml import XmlInputSource, XmlToolSource
 from .yaml import YamlToolSource
 
+from ..fetcher import DEFAULT_TOOL_LOCATION_FETCHER
+
 log = logging.getLogger(__name__)
 
 
-def get_tool_source(config_file=None, xml_tree=None, enable_beta_formats=True):
+def get_tool_source(config_file=None, xml_tree=None, enable_beta_formats=True, tool_location_fetcher=None):
     """Return a ToolSource object corresponding to supplied source.
 
     The supplied source may be specified as a file path (using the config_file
@@ -27,6 +29,10 @@ def get_tool_source(config_file=None, xml_tree=None, enable_beta_formats=True):
     elif config_file is None:
         raise ValueError("get_tool_source called with invalid config_file None.")
 
+    if tool_location_fetcher is None:
+        tool_location_fetcher = DEFAULT_TOOL_LOCATION_FETCHER
+
+    config_file = tool_location_fetcher.to_tool_path(config_file)
     if not enable_beta_formats:
         tree = load_tool_xml(config_file)
         return XmlToolSource(tree, source_path=config_file)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ PACKAGES = [
     'galaxy.tools.toolbox.filters',
     'galaxy.tools.toolbox.lineages',
     'galaxy.tools.linters',
+    'galaxy.tools.locations',
     'galaxy.tools.deps',
     'galaxy.tools.deps.container_resolvers',
     'galaxy.tools.deps.mulled',


### PR DESCRIPTION
This allows Planemo to do some cool stuff like running CWL tools right from dockstore:

planemo run dockstore://quay.io/briandoconnor/dockstore-tool-md5sum job.json

But would also be useful for linting tools and such from URLs.