### PR TITLE
Cleanup after build

### DIFF
--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -84,6 +84,9 @@ inv.task('build')
         .at('/usr/local')
         .inImage(destination_base_image)
         .as(repo)
+    .using(conda_image)
+        .withHostConfig({binds = {"build:/data"}})
+        .run('rm', '-rf', '/data/dist')
 
 if VAR.TEST_BINDS == '' then
     inv.task('test')

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -194,7 +194,11 @@ class InvolucroContext(installable.InstallableContext):
 
     def exec_command(self, involucro_args):
         cmd = self.build_command(involucro_args)
-        return self.shell_exec(" ".join(cmd))
+        # Create ./build dir manually, otherwise Docker will do it as root
+        os.mkdir('./build')
+        res = self.shell_exec(" ".join(cmd))
+        os.rmdir('./build')
+        return res
 
     def is_installed(self):
         return os.path.exists(self.involucro_bin)


### PR DESCRIPTION
Cleanup after creating the images.
This is a little bit more complicated than usually, because Docker/Moby creates these dirs as root if we don't do it manually.

@jmchilton a new release would be wonderful!