### PR TITLE
Make mulled-search to search biocontainers instead of mulled repository by default

### DIFF
--- a/galaxy/tools/deps/mulled/mulled_search.py
+++ b/galaxy/tools/deps/mulled/mulled_search.py
@@ -112,8 +112,8 @@ class QuaySearch():
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description='Searches in a given quay organization for a repository')
-    parser.add_argument('-o', '--organization', dest='organization_string', default="mulled",
-                        help='Change organization. Default is mulled.')
+    parser.add_argument('-o', '--organization', dest='organization_string', default="biocontainers",
+                        help='Change organization. Default is biocontainers.')
     parser.add_argument('--non-strict', dest='non_strict', action="store_true",
                         help='Autocorrection of typos activated. Lists more results but can be confusing.\
                         For too many queries quay.io blocks the request and the results can be incomplete.')


### PR DESCRIPTION
Currently, `mulled-search` command searches `quay.io/mulled` repository for Docker images by default.
 However, [mulled project](https://github.com/BioContainers/mulled) is already merged to [biocontainers project](https://github.com/BioContainers).

This request makes `mulled-search` to seaches `quay.io/biocontainers` repository by default.
