### PR TITLE
More mulled-build-files fixes.

### DIFF
--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -138,7 +138,7 @@ def mull_targets(
     }
     repo = string.Template(repository_template).safe_substitute(repo_template_kwds)
 
-    if rebuild or "push" in command:
+    if not rebuild or "push" in command:
         repo_data = quay_repository(repo_template_kwds["namespace"], repo_template_kwds["image"])
 
         if not rebuild:
@@ -250,8 +250,6 @@ def add_build_arguments(parser):
     """Base arguments describing how to 'mull'."""
     parser.add_argument('--involucro-path', dest="involucro_path", default=None,
                         help="Path to involucro (if not set will look in working directory and on PATH).")
-    parser.add_argument('--force-rebuild', dest="force_rebuild", action="store_true",
-                        help="Rebuild package even if already published.")
     parser.add_argument('--dry-run', dest='dry_run', action="store_true",
                         help='Just print commands instead of executing them.')
     parser.add_argument('--verbose', dest='verbose', action="store_true",
@@ -268,6 +266,7 @@ def add_build_arguments(parser):
                         help="Change to specified version of Conda before installing packages.")
     parser.add_argument('--oauth-token', dest="oauth_token", default=None,
                         help="If set, use this token when communicating with quay.io API.")
+    parser.add_argument('--check-published', dest="rebuild", action='store_false')
 
 
 def add_single_image_arguments(parser):
@@ -321,6 +320,8 @@ def args_to_mull_targets_kwds(args):
         kwds["conda_version"] = args.conda_version
     if hasattr(args, "oauth_token"):
         kwds["oauth_token"] = args.oauth_token
+    if hasattr(args, "rebuild"):
+        kwds["rebuild"] = args.rebuild
 
     kwds["involucro_context"] = context_from_args(args)
 

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -146,7 +146,9 @@ def mull_targets(
 
             target_tag = None
             if ":" in repo_template_kwds["image"]:
-                target_tag = repo_template_kwds["image"].split(":", 1)[1]
+                image_name_parts = repo_template_kwds["image"].split(":")
+                assert len(image_name_parts) == 2, ": not allowed in image name [%s]" % repo_template_kwds["image"]
+                target_tag = image_name_parts[1]
 
             if tags and (target_tag is None or target_tag in tags):
                 raise BuildExistsException()

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -239,9 +239,10 @@ def ensure_installed(involucro_context, auto_init):
 
 
 def install_involucro(involucro_context=None, to_path=None):
-    to_path = involucro_context.involucro_bin
-    download_cmd = " ".join(commands.download_command(involucro_link(), to=to_path, quote_url=True))
-    full_cmd = "%s && chmod +x %s" % (download_cmd, to_path)
+    install_path = os.path.abspath(involucro_context.involucro_bin)
+    involucro_context.involucro_bin = install_path
+    download_cmd = " ".join(commands.download_command(involucro_link(), to=install_path, quote_url=True))
+    full_cmd = "%s && chmod +x %s" % (download_cmd, install_path)
     return involucro_context.shell_exec(full_cmd)
 
 

--- a/galaxy/tools/deps/mulled/mulled_build_channel.py
+++ b/galaxy/tools/deps/mulled/mulled_build_channel.py
@@ -87,6 +87,8 @@ def add_channel_arguments(parser):
     parser.add_argument('--diff-hours', dest='diff_hours', default="25",
                         help='If finding all recently changed recipes, use this number of hours.')
     parser.add_argument('--recipes-dir', dest="recipes_dir", default="./bioconda-recipes")
+    parser.add_argument('--force-rebuild', dest="force_rebuild", action="store_true",
+                        help="Rebuild package even if already published.")
 
 
 def main(argv=None):

--- a/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -34,9 +34,15 @@ def main(argv=None):
     parser.add_argument('files', metavar="FILES", default=".",
                         help="Path to directory (or single file) of TSV files describing composite recipes.")
     args = parser.parse_args()
-    for targets in generate_targets(args.files):
+    for (targets, image_build, name_override) in generate_targets(args.files):
         try:
-            mull_targets(targets, rebuild=False, **args_to_mull_targets_kwds(args))
+            mull_targets(
+                targets,
+                image_build=image_build,
+                name_override=name_override,
+                rebuild=False,
+                **args_to_mull_targets_kwds(args)
+            )
         except BuildExistsException:
             continue
 
@@ -63,7 +69,7 @@ def generate_targets(target_source):
 
 def line_to_targets(line_str):
     line = _parse_line(line_str)
-    return target_str_to_targets(line[0])
+    return (target_str_to_targets(line.targets), line.image_build, line.name_override)
 
 
 _Line = collections.namedtuple("_Line", ["targets", "image_build", "name_override"])

--- a/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -37,7 +37,7 @@ def main(argv=None):
     for (targets, image_build, name_override) in generate_targets(args.files):
         if not image_build and len(targets) > 1:
             # Specify an explict tag in this case.
-            image_build = "1"
+            image_build = "0"
         try:
             mull_targets(
                 targets,

--- a/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -35,6 +35,8 @@ def main(argv=None):
                         help="Path to directory (or single file) of TSV files describing composite recipes.")
     args = parser.parse_args()
     for (targets, image_build, name_override) in generate_targets(args.files):
+        if not image_build:
+            image_build = "1"
         try:
             mull_targets(
                 targets,

--- a/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -35,7 +35,8 @@ def main(argv=None):
                         help="Path to directory (or single file) of TSV files describing composite recipes.")
     args = parser.parse_args()
     for (targets, image_build, name_override) in generate_targets(args.files):
-        if not image_build:
+        if not image_build and len(targets) > 1:
+            # Specify an explict tag in this case.
             image_build = "1"
         try:
             mull_targets(

--- a/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -40,7 +40,6 @@ def main(argv=None):
                 targets,
                 image_build=image_build,
                 name_override=name_override,
-                rebuild=False,
                 **args_to_mull_targets_kwds(args)
             )
         except BuildExistsException:
@@ -76,7 +75,7 @@ _Line = collections.namedtuple("_Line", ["targets", "image_build", "name_overrid
 
 
 def _parse_line(line_str):
-    line_parts = line_str.split(" ")
+    line_parts = line_str.split("\t")
     assert len(line_parts) < 3, "Too many fields in line [%s], expect at most 3 - targets, image build number, and name override." % line_str
     line_parts += [None] * (3 - len(line_parts))
     return _Line(*line_parts)

--- a/galaxy/tools/deps/mulled/util.py
+++ b/galaxy/tools/deps/mulled/util.py
@@ -12,11 +12,11 @@ except ImportError:
     requests = None
 
 
-def create_repository(namespace, pkg_name, oauth_token):
+def create_repository(namespace, repo_name, oauth_token):
     assert oauth_token
     headers = {'Authorization': 'Bearer %s' % oauth_token}
     data = {
-        "repository": pkg_name,
+        "repository": repo_name,
         "namespace": namespace,
         "description": "",
         "visibility": "public",


### PR DESCRIPTION
- Add explicit option ``--check-published`` to mulled-build-*.
- Fix auto-installation of Involucro on first attempt.
- Handle explicit tags in mulled-build-files and add an implicit ``1`` tag if none found.
- Fix tab parsing in mulled-build-files.
- Various other fixes.

With these changes - the [Travis setup](https://travis-ci.org/jmchilton/multireqcontainers) in [jmchilton/multireqcontainers](https://github.com/jmchilton/multireqcontainers) seems to work properly.

Ping @bgruening.