### PR TITLE
Implement mulled containers v2.

### DIFF
--- a/galaxy/tools/deps/container_resolvers/mulled.py
+++ b/galaxy/tools/deps/container_resolvers/mulled.py
@@ -18,9 +18,10 @@ from ..mulled.mulled_build import (
 )
 from ..mulled.mulled_build_tool import requirements_to_mulled_targets
 from ..mulled.util import (
-    image_name,
     mulled_tags_for,
     split_tag,
+    v1_image_name,
+    v2_image_name,
 )
 from ..requirements import ContainerDescription
 
@@ -28,13 +29,15 @@ log = logging.getLogger(__name__)
 
 
 CachedMulledImageSingleTarget = collections.namedtuple("CachedMulledImageSingleTarget", ["package_name", "version", "build", "image_identifier"])
-CachedMulledImageMultiTarget = collections.namedtuple("CachedMulledImageMultiTarget", ["hash", "image_identifier"])
+CachedV1MulledImageMultiTarget = collections.namedtuple("CachedV1MulledImageMultiTarget", ["hash", "build", "image_identifier"])
+CachedV2MulledImageMultiTarget = collections.namedtuple("CachedV2MulledImageMultiTarget", ["package_hash", "version_hash", "build", "image_identifier"])
 
 CachedMulledImageSingleTarget.multi_target = False
-CachedMulledImageMultiTarget.multi_target = True
+CachedV1MulledImageMultiTarget.multi_target = "v1"
+CachedV2MulledImageMultiTarget.multi_target = "v2"
 
 
-def list_cached_mulled_images(namespace=None):
+def list_cached_mulled_images(namespace=None, hash_func="v2"):
     command = build_docker_images_command(truncate=True, sudo=False)
     command = "%s | tail -n +2 | tr -s ' ' | cut -d' ' -f1,2" % command
     images_and_versions = check_output(command)
@@ -44,15 +47,36 @@ def list_cached_mulled_images(namespace=None):
         image_name, version = line.split(" ", 1)
         identifier = "%s:%s" % (image_name, version)
         url, namespace, package_description = image_name.split("/")
+        if not version or version == "latest":
+            version = None
 
+        image = None
         if package_description.startswith("mulled-v1-"):
+            if hash_func == "v2":
+                return None
+
             hash = package_description
-            image = CachedMulledImageMultiTarget(hash, identifier)
+            build = None
+            if version and version.isdigit():
+                build = version
+            image = CachedV1MulledImageMultiTarget(hash, build, identifier)
+        elif package_description.startswith("mulled-v2-"):
+            if hash_func == "v1":
+                return None
+
+            version_hash = None
+            build = None
+
+            if version and "-" in version:
+                version_hash, build = version.rsplit("-", 1)
+            elif version.isdigit():
+                version_hash, build = None, version
+            elif version:
+                log.debug("Unparsable mulled image tag encountered [%s]" % version)
+
+            image = CachedV2MulledImageMultiTarget(package_description, version_hash, build, identifier)
         else:
             build = None
-            if not version or version == "latest":
-                version = None
-
             if version and "--" in version:
                 version, build = split_tag(version)
 
@@ -60,7 +84,9 @@ def list_cached_mulled_images(namespace=None):
 
         return image
 
-    return [output_line_to_image(_) for _ in filter(name_filter, images_and_versions.splitlines())]
+    # TODO: Sort on build ...
+    raw_images = [output_line_to_image(_) for _ in filter(name_filter, images_and_versions.splitlines())]
+    return [i for i in raw_images if i is not None]
 
 
 def get_filter(namespace):
@@ -68,11 +94,11 @@ def get_filter(namespace):
     return lambda name: name.startswith(prefix) and name.count("/") == 2
 
 
-def cached_container_description(targets, namespace):
+def cached_container_description(targets, namespace, hash_func="v2"):
     if len(targets) == 0:
         return None
 
-    cached_images = list_cached_mulled_images(namespace)
+    cached_images = list_cached_mulled_images(namespace, hash_func=hash_func)
     image = None
     if len(targets) == 1:
         target = targets[0]
@@ -84,10 +110,32 @@ def cached_container_description(targets, namespace):
             if not target.version or target.version == cached_image.version:
                 image = cached_image
                 break
-    else:
-        name = image_name(targets)
+    elif hash_func == "v2":
+        name = v2_image_name(targets)
+        if ":" in name:
+            package_hash, version_hash = name.split(":", 2)
+        else:
+            package_hash, version_hash = name, None
+
         for cached_image in cached_images:
-            if not cached_image.multi_target:
+            if cached_image.multi_target != "v2":
+                continue
+
+            if version_hash is None:
+                # Just match on package hash...
+                if package_hash == cached_image.package_hash:
+                    image = cached_image
+                    break
+            else:
+                # Match on package and version hash...
+                if package_hash == cached_image.package_hash and version_hash == cached_image.version_hash:
+                    image = cached_image
+                    break
+
+    elif hash_func == "v1":
+        name = v1_image_name(targets)
+        for cached_image in cached_images:
+            if cached_image.multi_target != "v1":
                 continue
 
             if name == cached_image.hash:
@@ -109,16 +157,17 @@ class CachedMulledContainerResolver(ContainerResolver):
 
     resolver_type = "cached_mulled"
 
-    def __init__(self, app_info=None, namespace=None):
+    def __init__(self, app_info=None, namespace=None, hash_func="v2"):
         super(CachedMulledContainerResolver, self).__init__(app_info)
         self.namespace = namespace
+        self.hash_func = hash_func
 
     def resolve(self, enabled_container_types, tool_info):
         if tool_info.requires_galaxy_python_environment:
             return None
 
         targets = mulled_targets(tool_info)
-        return cached_container_description(targets, self.namespace)
+        return cached_container_description(targets, self.namespace, hash_func=self.hash_func)
 
     def __str__(self):
         return "CachedMulledContainerResolver[namespace=%s]" % self.namespace
@@ -130,9 +179,10 @@ class MulledContainerResolver(ContainerResolver):
 
     resolver_type = "mulled"
 
-    def __init__(self, app_info=None, namespace="biocontainers"):
+    def __init__(self, app_info=None, namespace="biocontainers", hash_func="v2"):
         super(MulledContainerResolver, self).__init__(app_info)
         self.namespace = namespace
+        self.hash_func = hash_func
 
     def resolve(self, enabled_container_types, tool_info):
         if tool_info.requires_galaxy_python_environment:
@@ -162,10 +212,25 @@ class MulledContainerResolver(ContainerResolver):
                 version, build = split_tag(tags[0])
                 name = "%s:%s--%s" % (target.package_name, version, build)
         else:
-            base_image_name = image_name(targets)
-            tags = mulled_tags_for(self.namespace, base_image_name)
-            if tags:
-                name = "%s:%s" % (base_image_name, tags[0])
+            def tags_if_available(image_name):
+                if ":" in image_name:
+                    repo_name, tag_prefix = image_name.split(":", 2)
+                else:
+                    repo_name = image_name
+                    tag_prefix = None
+                tags = mulled_tags_for(self.namespace, repo_name, tag_prefix=tag_prefix)
+                return tags
+
+            if self.hash_func == "v2":
+                base_image_name = v2_image_name(targets)
+                tags = tags_if_available(base_image_name)
+                if tags:
+                    name = "%s:%s" % (base_image_name, tags[0])
+            elif self.hash_func == "v1":
+                base_image_name = v1_image_name(targets)
+                tags = tags_if_available(base_image_name)
+                if tags:
+                    name = "%s:%s" % (base_image_name, tags[0])
 
         if name:
             return ContainerDescription(
@@ -183,12 +248,13 @@ class BuildMulledContainerResolver(ContainerResolver):
 
     resolver_type = "build_mulled"
 
-    def __init__(self, app_info=None, namespace="local", **kwds):
+    def __init__(self, app_info=None, namespace="local", hash_func="v2", **kwds):
         super(BuildMulledContainerResolver, self).__init__(app_info)
         self._involucro_context_kwds = {
             'involucro_bin': self._get_config_option("involucro_path", None)
         }
         self.namespace = namespace
+        self.hash_func = hash_func
         self._mulled_kwds = {
             'namespace': namespace,
             'channels': self._get_config_option("channels", DEFAULT_CHANNELS, prefix="mulled"),
@@ -206,9 +272,10 @@ class BuildMulledContainerResolver(ContainerResolver):
         mull_targets(
             targets,
             involucro_context=self._get_involucro_context(),
+            hash_func=self.hash_func,
             **self._mulled_kwds
         )
-        return cached_container_description(targets, self.namespace)
+        return cached_container_description(targets, self.namespace, hash_func=self.hash_func)
 
     def _get_involucro_context(self):
         involucro_context = InvolucroContext(**self._involucro_context_kwds)

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -130,7 +130,7 @@ class BuildExistsException(Exception):
 
 def mull_targets(
     targets, involucro_context=None,
-    command="build", channels=DEFAULT_CHANNELS, namespace="mulled",
+    command="build", channels=DEFAULT_CHANNELS, namespace="biocontainers",
     test='true', test_files=None, image_build=None, name_override=None,
     repository_template=DEFAULT_REPOSITORY_TEMPLATE, dry_run=False,
     conda_version=None, verbose=False, binds=DEFAULT_BINDS, rebuild=True,
@@ -275,7 +275,7 @@ def add_build_arguments(parser):
                         help='Just print commands instead of executing them.')
     parser.add_argument('--verbose', dest='verbose', action="store_true",
                         help='Cause process to be verbose.')
-    parser.add_argument('-n', '--namespace', dest='namespace', default="mulled",
+    parser.add_argument('-n', '--namespace', dest='namespace', default="biocontainers",
                         help='quay.io namespace.')
     parser.add_argument('-r', '--repository_template', dest='repository_template', default=DEFAULT_REPOSITORY_TEMPLATE,
                         help='Docker repository target for publication (only quay.io or compat. API is currently supported).')

--- a/galaxy/tools/deps/mulled/util.py
+++ b/galaxy/tools/deps/mulled/util.py
@@ -49,12 +49,14 @@ def quay_repository(namespace, pkg_name):
     return data
 
 
-def mulled_tags_for(namespace, image):
+def mulled_tags_for(namespace, image, tag_prefix=None):
     """Fetch remote tags available for supplied image name.
 
     The result will be sorted so newest tags are first.
     """
     tags = quay_versions(namespace, image)
+    if tag_prefix is not None:
+        tags = [t for t in tags if t.startswith(tag_prefix)]
     tags = version_sorted(tags)
     return tags
 
@@ -95,25 +97,49 @@ def conda_build_target_str(target):
     return rval
 
 
-def image_name(targets, image_build=None, name_override=None):
+def _simple_image_name(targets, image_build=None):
+    target = targets[0]
+    suffix = ""
+    if target.version is not None:
+        if image_build is not None:
+            print("WARNING: Hard-coding image build instead of using Conda build - this is not recommended.")
+            suffix = image_build
+        else:
+            suffix += ":%s" % target.version
+            build = target.build
+            if build is not None:
+                suffix += "--%s" % build
+    return "%s%s" % (target.package_name, suffix)
+
+
+def v1_image_name(targets, image_build=None, name_override=None):
+    """Generate mulled hash version 1 container identifier for supplied arguments.
+
+    If a single target is specified, simply use the supplied name and version as
+    the repository name and tag respectively. If multiple targets are supplied,
+    hash the package names and versions together as the repository name. For mulled
+    version 1 containers the image build is the repository tag (if supplied).
+
+    >>> single_targets = [build_target("samtools", version="1.3.1")]
+    >>> v1_image_name(single_targets)
+    'samtools:1.3.1'
+    >>> multi_targets = [build_target("samtools", version="1.3.1"), build_target("bwa", version="0.7.13")]
+    >>> v1_image_name(multi_targets)
+    'mulled-v1-b06ecbd9141f0dbbc0c287375fc0813adfcbdfbd'
+    >>> multi_targets_on_versionless = [build_target("samtools", version="1.3.1"), build_target("bwa")]
+    >>> v1_image_name(multi_targets_on_versionless)
+    'mulled-v1-bda945976caa5734347fbf7f35066d9f58519e0c'
+    >>> multi_targets_versionless = [build_target("samtools"), build_target("bwa")]
+    >>> v1_image_name(multi_targets_versionless)
+    'mulled-v1-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40'
+    """
     if name_override is not None:
         print("WARNING: Overriding mulled image name, auto-detection of 'mulled' package attributes will fail to detect result.")
         return name_override
 
     targets = list(targets)
     if len(targets) == 1:
-        target = targets[0]
-        suffix = ""
-        if target.version is not None:
-            if image_build is not None:
-                print("WARNING: Hard-coding image build instead of using Conda build - this is not recommended.")
-                suffix = image_build
-            else:
-                suffix += ":%s" % target.version
-                build = target.build
-                if build is not None:
-                    suffix += "--%s" % build
-        return "%s%s" % (target.package_name, suffix)
+        return _simple_image_name(targets, image_build=image_build)
     else:
         targets_order = sorted(targets, key=lambda t: t.package_name)
         requirements_buffer = "\n".join(map(conda_build_target_str, targets_order))
@@ -123,6 +149,66 @@ def image_name(targets, image_build=None, name_override=None):
         return "mulled-v1-%s%s" % (m.hexdigest(), suffix)
 
 
+def v2_image_name(targets, image_build=None, name_override=None):
+    """Generate mulled hash version 2 container identifier for supplied arguments.
+
+    If a single target is specified, simply use the supplied name and version as
+    the repository name and tag respectively. If multiple targets are supplied,
+    hash the package names as the repository name and hash the package versions (if set)
+    as the tag.
+
+    >>> single_targets = [build_target("samtools", version="1.3.1")]
+    >>> v2_image_name(single_targets)
+    'samtools:1.3.1'
+    >>> multi_targets = [build_target("samtools", version="1.3.1"), build_target("bwa", version="0.7.13")]
+    >>> v2_image_name(multi_targets)
+    'mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:4d0535c94ef45be8459f429561f0894c3fe0ebcf'
+    >>> multi_targets_on_versionless = [build_target("samtools", version="1.3.1"), build_target("bwa")]
+    >>> v2_image_name(multi_targets_on_versionless)
+    'mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:b0c847e4fb89c343b04036e33b2daa19c4152cf5'
+    >>> multi_targets_versionless = [build_target("samtools"), build_target("bwa")]
+    >>> v2_image_name(multi_targets_versionless)
+    'mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40'
+    """
+    if name_override is not None:
+        print("WARNING: Overriding mulled image name, auto-detection of 'mulled' package attributes will fail to detect result.")
+        return name_override
+
+    targets = list(targets)
+    if len(targets) == 1:
+        return _simple_image_name(targets, image_build=image_build)
+    else:
+        targets_order = sorted(targets, key=lambda t: t.package_name)
+        package_name_buffer = "\n".join(map(lambda t: t.package_name, targets_order))
+        package_hash = hashlib.sha1()
+        package_hash.update(package_name_buffer.encode())
+
+        versions = map(lambda t: t.version, targets_order)
+        if any(versions):
+            # Only hash versions if at least one package has versions...
+            version_name_buffer = "\n".join(map(lambda t: t.version or "null", targets_order))
+            version_hash = hashlib.sha1()
+            version_hash.update(version_name_buffer.encode())
+            version_hash_str = version_hash.hexdigest()
+        else:
+            version_hash_str = ""
+
+        if not image_build:
+            build_suffix = ""
+        elif version_hash_str:
+            # tagged verson is <version_hash>-<build>
+            build_suffix = "-%s" % image_build
+        else:
+            # tagged version is simply the build
+            build_suffix = image_build
+        suffix = ""
+        if version_hash_str or build_suffix:
+            suffix = ":%s%s" % (version_hash_str, build_suffix)
+        return "mulled-v2-%s%s" % (package_hash.hexdigest(), suffix)
+
+
+image_name = v1_image_name  # deprecated
+
 __all__ = (
     "build_target",
     "conda_build_target_str",
@@ -131,5 +217,7 @@ __all__ = (
     "quay_versions",
     "split_tag",
     "Target",
+    "v1_image_name",
+    "v2_image_name",
     "version_sorted",
 )


### PR DESCRIPTION
For a given set of packages and versions, the v1 containers had names and versions like:

```
mulled-v1-<hash_of_packages_and_versions>:<build_number>
```

Here the quay.io repository has a unique name per combination of packages and versions - and the repository tag (the part after the :) is solely used to specify a build number (a mechanism allowing us to increment and rebuild containers with same recipes if they are broken in some way - mirroring closely the conda build number).

The version of the v2 hash looks like:

```
mulled-v2-<hash_of_packages>:<hash_of_versions>-<build_number>
```

Here a repository is only created for each combination of packages - different combinations of versions are represented as different tags within that repository.

This commit preserves backward compatibility - but since we are aware of no biocontainers published in the wild it would probably be a okay idea to eliminate the backward compatability once we ready to merge into Galaxy - at least when looking for published containers.

Ping @bgruening - I still need to port this over to Galaxy and test it - but based on the PR description do you think this is a good course forward? I also want to special case a list of requirements where none of them specify a version - in that case we should probably not generate a version hash and simply rely on build numbers.
