### PR TITLE
increase container size by default

### DIFF
--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -104,8 +104,8 @@ if VAR.SINGULARITY ~= '' then
         .withHostConfig({binds = {"build:/data",singularity_image_dir .. ":/import"}, privileged = true})
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
         -- for small containers (less than 7MB), double the size otherwise, add a little bit more as half the conda size
-        .run("size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
-        .run("singularity create --size `size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
+        .run("size=$(du -sc  /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
+        .run("singularity create --size `size=$(du -sc  ./data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
         .run('mkdir -p /usr/local/var/singularity/mnt/container && singularity bootstrap /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity')
         .run('chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
 end

--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -103,10 +103,9 @@ if VAR.SINGULARITY ~= '' then
         .using(singularity_image)
         .withHostConfig({binds = {"build:/data",singularity_image_dir .. ":/import"}, privileged = true})
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
-        -- this will create a container that is the size of our conda dependencies + 20MiB
-        -- The 20 MiB can be improved at some point, but this seems to work for now.
-        .run("du -sc  /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)+20}'")
-        .run("singularity create --size `du -sc  /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)+20}'` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
+        -- for small containers (less than 7MB), double the size otherwise, add a little bit more as half the conda size
+        .run("size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ "$size" -lt "7" ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
+        .run("singularity create --size `size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ "$size" -lt "7" ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
         .run('mkdir -p /usr/local/var/singularity/mnt/container && singularity bootstrap /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity')
         .run('chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
 end

--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -105,7 +105,7 @@ if VAR.SINGULARITY ~= '' then
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
         -- for small containers (less than 7MB), double the size otherwise, add a little bit more as half the conda size
         .run("size=$(du -sc  /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
-        .run("singularity create --size `size=$(du -sc  ./data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
+        .run("singularity create --size `size=$(du -sc /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
         .run('mkdir -p /usr/local/var/singularity/mnt/container && singularity bootstrap /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity')
         .run('chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
 end

--- a/galaxy/tools/deps/mulled/invfile.lua
+++ b/galaxy/tools/deps/mulled/invfile.lua
@@ -104,8 +104,8 @@ if VAR.SINGULARITY ~= '' then
         .withHostConfig({binds = {"build:/data",singularity_image_dir .. ":/import"}, privileged = true})
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
         -- for small containers (less than 7MB), double the size otherwise, add a little bit more as half the conda size
-        .run("size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ "$size" -lt "7" ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
-        .run("singularity create --size `size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ "$size" -lt "7" ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
+        .run("size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
+        .run("singularity create --size `size=$(du -sc  ./singularity_import/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
         .run('mkdir -p /usr/local/var/singularity/mnt/container && singularity bootstrap /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity')
         .run('chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
 end

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -391,7 +391,7 @@ def args_to_mull_targets_kwds(args):
         kwds["rebuild"] = args.rebuild
     if hasattr(args, "hash"):
         kwds["hash_func"] = args.hash
-    if hasattr(args, "singularity_image_dir"):
+    if hasattr(args, "singularity_image_dir") and args.singularity_image_dir:
         kwds["singularity_image_dir"] = args.singularity_image_dir
 
     kwds["involucro_context"] = context_from_args(args)


### PR DESCRIPTION
The problem is that we need to say how big the Singularity container should be at the bootstrap phase. This is not easy to predict and nearly arbitrary. The Docker2Singularity project has the same problem and came up with a heuristic or more an upper bound. Means that most of the containers will have the 1.6xconda_size :( - if this is ok for you please merge.

One additional question regarding https://github.com/galaxyproject/galaxy-lib/pull/67/files#diff-bca9d67648abf35f09fa218eff56e9efR394 ... this is not what you wanted right? But in my testing all these attributes are part of args. So when `singularity_image_dir` is not specified it is still part of args with value of None ... which overwrites the default settings in mulled_target and ends up with a NoneType error. So either we set the defaults in the argparse definition or fix args_to_mull_targets_kwds.

Needed to make https://github.com/BioContainers/multi-package-containers/pull/281 pass.
