### PR TITLE
Raise warnings rather than quietly logging for RST linting

### DIFF
--- a/galaxy/tools/linters/help.py
+++ b/galaxy/tools/linters/help.py
@@ -39,7 +39,7 @@ def rst_invalid(text):
     """
     invalid_rst = False
     try:
-        rst_to_html(text)
+        rst_to_html(text, error=True)
     except Exception as e:
         invalid_rst = str(e)
     return invalid_rst

--- a/galaxy/util/__init__.py
+++ b/galaxy/util/__init__.py
@@ -760,7 +760,7 @@ class Params( object ):
         self.__dict__.update(values)
 
 
-def rst_to_html( s ):
+def rst_to_html( s, error=False ):
     """Convert a blob of reStructuredText to HTML"""
     log = logging.getLogger( "docutils" )
 
@@ -770,6 +770,8 @@ def rst_to_html( s ):
     class FakeStream( object ):
         def write( self, str ):
             if len( str ) > 0 and not str.isspace():
+                if error:
+                    raise Exception( str )
                 log.warning( str )
 
     settings_overrides = {


### PR DESCRIPTION
Before this change:

```
$ planemo lint test.xml
Applying linter inputs... CHECK
.. INFO: Found 1 input parameters.
<string>:20: (WARNING/2) Title underline too short.

testsadfsadf
=====

Applying linter help... CHECK
.. CHECK: Tool contains help section.
.. CHECK: Help contains valid reStructuredText
<snip>
Applying linter tool_xsd... CHECK
.. INFO: File validates against XML schema.
(.venv) [hxr@mk:~/arbeit/planemo]$
```

After this change:

```
$ planemo lint test.xml
Applying linter help... WARNING
.. WARNING: Invalid reStructuredText found in help - [<string>:20: (WARNING/2) Title underline too short.

testsadfsadf
=====
].
.. CHECK: Tool contains help section
<snip>
Applying linter command... CHECK
.. INFO: Tool contains a command.
Applying linter tool_xsd... CHECK
.. INFO: File validates against XML schema.
Failed linting
```