### PR TITLE
catches an error when conda search does not find the package at all

### DIFF
--- a/galaxy/tools/deps/conda_util.py
+++ b/galaxy/tools/deps/conda_util.py
@@ -459,7 +459,13 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
     else:
         search_cmd.extend(conda_context._override_channels_args)
     search_cmd.append(conda_target.package)
-    res = commands.execute(search_cmd)
+
+    try:
+        res = commands.execute(search_cmd)
+    except commands.CommandLineException as e:
+        log.warning(e)
+        return (None, None)
+
     hits = json.loads(res).get(conda_target.package, [])
     hits = sorted(hits, key=lambda hit: LooseVersion(hit['version']), reverse=True)
 


### PR DESCRIPTION
This was causing bad error messages in planemo-monitor: https://travis-ci.org/galaxyproject/planemo-monitor#L892

```
Handling conda_targets [frozenset([CondaTarget[viennarna,version=2.2.5], CondaTarget[targetscan,version=7.0.2]])]
Traceback (most recent call last):
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/bin/planemo", line 11, in <module>
    sys.exit(planemo())
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/planemo/cli.py", line 178, in handle_blended_options
    return f(*args, **kwds)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/planemo/commands/cmd_container_register.py", line 85, in cli
    best_hit, exact = best_practice_search(conda_target, conda_context=conda_context)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/planemo/conda.py", line 155, in best_practice_search
    return conda_util.best_search_result(conda_target, conda_context=conda_context, channels_override=BEST_PRACTICE_CHANNELS, offline=offline)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/galaxy/tools/deps/conda_util.py", line 462, in best_search_result
    res = commands.execute(search_cmd)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/galaxy/tools/deps/commands.py", line 75, in execute
    return _wait(cmds, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
  File "/home/travis/build/galaxyproject/planemo-monitor/.venv/local/lib/python2.7/site-packages/galaxy/tools/deps/commands.py", line 95, in _wait
    raise CommandLineException(argv_to_str(cmds), stdout, stderr, p.returncode)
galaxy.tools.deps.commands.CommandLineException: Failed to execute command-line /home/travis/miniconda3/bin/conda search --full-name --json --override-channels --channel bioconda --channel conda-forge --channel defaults --channel r targetscan, stderr was:
-------->>begin stderr<<--------
None
-------->>end stderr<<--------
-------->>begin stdout<<--------
{
  "caused_by": "None",
  "channels": "\n  - https://conda.anaconda.org/bioconda/linux-64\n  - https://conda.anaconda.org/bioconda/noarch\n  - https://conda.anaconda.org/conda-forge/linux-64\n  - https://conda.anaconda.org/conda-forge/noarch\n  - https://repo.continuum.io/pkgs/free/linux-64\n  - https://repo.continuum.io/pkgs/free/noarch\n  - https://repo.continuum.io/pkgs/r/linux-64\n  - https://repo.continuum.io/pkgs/r/noarch\n  - https://repo.continuum.io/pkgs/pro/linux-64\n  - https://repo.continuum.io/pkgs/pro/noarch\n  - https://conda.anaconda.org/r/linux-64\n  - https://conda.anaconda.org/r/noarch",
  "error": "PackageNotFoundError: Packages missing in current channels:\n            \n  - targetscan\n\nWe have searched for the packages in the following channels:\n            \n  - https://conda.anaconda.org/bioconda/linux-64\n  - https://conda.anaconda.org/bioconda/noarch\n  - https://conda.anaconda.org/conda-forge/linux-64\n  - https://conda.anaconda.org/conda-forge/noarch\n  - https://repo.continuum.io/pkgs/free/linux-64\n  - https://repo.continuum.io/pkgs/free/noarch\n  - https://repo.continuum.io/pkgs/r/linux-64\n  - https://repo.continuum.io/pkgs/r/noarch\n  - https://repo.continuum.io/pkgs/pro/linux-64\n  - https://repo.continuum.io/pkgs/pro/noarch\n  - https://conda.anaconda.org/r/linux-64\n  - https://conda.anaconda.org/r/noarch\n            ",
  "exception_name": "PackageNotFoundError",
  "exception_type": "<class 'conda.exceptions.PackageNotFoundError'>",
  "message": "Packages missing in current channels:\n            \n  - targetscan\n\nWe have searched for the packages in the following channels:\n            \n  - https://conda.anaconda.org/bioconda/linux-64\n  - https://conda.anaconda.org/bioconda/noarch\n  - https://conda.anaconda.org/conda-forge/linux-64\n  - https://conda.anaconda.org/conda-forge/noarch\n  - https://repo.continuum.io/pkgs/free/linux-64\n  - https://repo.continuum.io/pkgs/free/noarch\n  - https://repo.continuum.io/pkgs/r/linux-64\n  - https://repo.continuum.io/pkgs/r/noarch\n  - https://repo.continuum.io/pkgs/pro/linux-64\n  - https://repo.continuum.io/pkgs/pro/noarch\n  - https://conda.anaconda.org/r/linux-64\n  - https://conda.anaconda.org/r/noarch\n            ",
  "pkg": "\n  - targetscan"
}
-------->>end stdout<<--------
```