### PR TITLE
mulled: use shlex.quote to escape single quotes in test

### DIFF
--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -17,6 +17,10 @@ import string
 import subprocess
 import sys
 from sys import platform as _platform
+try:
+    from shlex import quote as shlex_quote
+except ImportError:
+    from pipes import quote as shlex_quote
 
 try:
     import yaml
@@ -195,7 +199,7 @@ def mull_targets(
     involucro_args = [
         '-f', '%s/invfile.lua' % DIRNAME,
         '-set', "CHANNELS='%s'" % channels,
-        '-set', "TEST='%s'" % test,
+        '-set', "TEST=%s" % shlex_quote(test),
         '-set', "TARGETS='%s'" % target_str,
         '-set', "REPO='%s'" % repo,
         '-set', "BINDS='%s'" % bind_str,

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -17,11 +17,8 @@ import string
 import subprocess
 import sys
 from sys import platform as _platform
-try:
-    from shlex import quote as shlex_quote
-except ImportError:
-    from pipes import quote as shlex_quote
 
+from six.moves import shlex_quote
 try:
     import yaml
 except ImportError:


### PR DESCRIPTION
Just saw that `'-set', "TEST='%s'" % test,`. With `shlex.quote` (`pipes.quote` in Python 2.7) you should be able to safely use single quotes in the test commands.