### PR TITLE
add missing markupsafe dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ six>=1.9.0
 docutils
 pyyaml
 packaging
+markupsafe


### PR DESCRIPTION
While updating the Bioconda recipe, I noticed `markupsafe` (imported at https://github.com/galaxyproject/galaxy-lib/blob/18.5.4/galaxy/tools/toolbox/base.py#L8) is missing from the dependencies.