### PR TITLE
Use admin=True when getting test data path.

### DIFF
--- a/galaxy/tools/verify/interactor.py
+++ b/galaxy/tools/verify/interactor.py
@@ -228,8 +228,7 @@ class GalaxyInteractorApi(object):
 
     @nottest
     def test_data_path(self, tool_id, filename):
-        admin_key = self.master_api_key
-        response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), key=admin_key)
+        response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
         assert response.status_code == 200
         return response.json()
 


### PR DESCRIPTION
Fixes abstraction leakage introduced in #104 caught by @nsoranzo.