### PR TITLE
catch error during conda search

### DIFF
--- a/galaxy/tools/deps/conda_util.py
+++ b/galaxy/tools/deps/conda_util.py
@@ -12,6 +12,7 @@ import packaging.version
 import six
 from six.moves import shlex_quote
 
+from galaxy.tools.deps.commands import CommandLineException
 from galaxy.util import unicodify
 from . import (
     commands,
@@ -508,7 +509,7 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
         res = unicodify(res)
         hits = json.loads(res).get(conda_target.package, [])
         hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
-    except:
+    except CommandLineException:
         log.error("Could not execute: '%s'", search_cmd)
         hits = []
 

--- a/galaxy/tools/deps/conda_util.py
+++ b/galaxy/tools/deps/conda_util.py
@@ -503,10 +503,14 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
     else:
         search_cmd.extend(conda_context._override_channels_args)
     search_cmd.append(conda_target.package)
-    res = commands.execute(search_cmd)
-    res = unicodify(res)
-    hits = json.loads(res).get(conda_target.package, [])
-    hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
+    try:
+        res = commands.execute(search_cmd)
+        res = unicodify(res)
+        hits = json.loads(res).get(conda_target.package, [])
+        hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
+    except:
+        log.error("Could not execute: '%s'", search_cmd)
+        hits = []
 
     if len(hits) == 0:
         return (None, None)


### PR DESCRIPTION
If a package could not be found (under some strange reasons) in conda an exception was raised and the function did not returned anything.
This catches the error and pretends that no hit was found and prints an error message.

This should fix planemo_monitor.