### PR TITLE
Report a lint error if test output name does not match tool outputs

### DIFF
--- a/galaxy/tools/linters/tests.py
+++ b/galaxy/tools/linters/tests.py
@@ -33,7 +33,7 @@ def lint_tsts(tool_xml, lint_ctx):
                 lint_ctx.warn("Found output tag without a name defined.")
             else:
                 if name not in output_data_names:
-                    lint_ctx.warn("Found output tag with unknown name [%s], valid names [%s]" % (name, output_data_names))
+                    lint_ctx.error("Found output tag with unknown name [%s], valid names [%s]" % (name, output_data_names))
 
         for output_collection in test.findall("output_collection"):
             found_output_test = True


### PR DESCRIPTION
not a warning. Fix https://github.com/galaxyproject/planemo/issues/858 .