### PR TITLE
Makes --test optional for involucro

### DIFF
--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -215,7 +215,7 @@ def mull_targets(
         involucro_args.extend(["-set", "SINGULARITY_IMAGE_DIR='%s'" % singularity_image_dir])
         involucro_args.extend(["-set", "USER_ID='%s:%s'" % (os.getuid(), os.getgid())])
     if test:
-        involucro_args.extend(["-set", "TEST=%s" % shlex_quote(test))
+        involucro_args.extend(["-set", "TEST=%s" % shlex_quote(test)])
     if conda_version is not None:
         verbose = "--verbose" if verbose else "--quiet"
         involucro_args.extend(["-set", "PREINSTALL='conda install %s --yes conda=%s'" % (verbose, conda_version)])

--- a/galaxy/tools/deps/mulled/mulled_build.py
+++ b/galaxy/tools/deps/mulled/mulled_build.py
@@ -197,7 +197,6 @@ def mull_targets(
     involucro_args = [
         '-f', '%s/invfile.lua' % DIRNAME,
         '-set', "CHANNELS='%s'" % channels,
-        '-set', "TEST=%s" % shlex_quote(test),
         '-set', "TARGETS='%s'" % target_str,
         '-set', "REPO='%s'" % repo,
         '-set', "BINDS='%s'" % bind_str,
@@ -215,6 +214,8 @@ def mull_targets(
         involucro_args.extend(["-set", "SINGULARITY_IMAGE_NAME='%s'" % singularity_image_name])
         involucro_args.extend(["-set", "SINGULARITY_IMAGE_DIR='%s'" % singularity_image_dir])
         involucro_args.extend(["-set", "USER_ID='%s:%s'" % (os.getuid(), os.getgid())])
+    if test:
+        involucro_args.extend(["-set", "TEST=%s" % shlex_quote(test))
     if conda_version is not None:
         verbose = "--verbose" if verbose else "--quiet"
         involucro_args.extend(["-set", "PREINSTALL='conda install %s --yes conda=%s'" % (verbose, conda_version)])


### PR DESCRIPTION
Currently, if no --test is given to mulled_build.py, involucro is passed an empty string test, which generates a failure with some packages. This PR avoids setting involucro --test if the same has not been set when calling mulled_build.py. I expect this to mean that involucro will use the default tests set in the manifest of the package.