### PR TITLE
Remove deprecated ``sudo: false`` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python: 2.7
 env:
   - TOX_ENV=py27-lint


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration